### PR TITLE
Feature/#11 LV 5 구현

### DIFF
--- a/HarryPotterSeriesApp/Home/BookDetails/Body/Chapters/View/ChaptersView.swift
+++ b/HarryPotterSeriesApp/Home/BookDetails/Body/Chapters/View/ChaptersView.swift
@@ -22,6 +22,7 @@ class ChaptersView: UIView {
         let label = UILabel()
         label.text = "Chapters"
         label.font = .systemFont(ofSize: 18, weight: .bold)
+        label.textAlignment = .left
         label.textColor = .black
         
         return label
@@ -53,6 +54,7 @@ class ChaptersView: UIView {
             label.font = .systemFont(ofSize: 14)
             label.textColor = .darkGray
             chaptersStack.addArrangedSubview(label)
+            label.textAlignment = .left
         }
         
     }

--- a/HarryPotterSeriesApp/Home/BookDetails/Body/Dedication/View/DedicationView.swift
+++ b/HarryPotterSeriesApp/Home/BookDetails/Body/Dedication/View/DedicationView.swift
@@ -13,7 +13,6 @@ class DedicationView: UIView {
     private lazy var dedicationStack: UIStackView = {
         let view = UIStackView(arrangedSubviews: [title, dedication])
         view.axis = .vertical
-        view.alignment = .leading
         view.spacing = 8
         return view
     }()
@@ -22,6 +21,7 @@ class DedicationView: UIView {
         let label = UILabel()
         label.text = "Dedication"
         label.font = .systemFont(ofSize: 18, weight: .bold)
+        label.textAlignment = .left
         label.textColor = .black
         return label
     }()
@@ -32,6 +32,7 @@ class DedicationView: UIView {
         label.textColor = .darkGray
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
+        label.textAlignment = .left
         return label
     }()
     

--- a/HarryPotterSeriesApp/Home/BookDetails/Body/Summary/View/SummaryView.swift
+++ b/HarryPotterSeriesApp/Home/BookDetails/Body/Summary/View/SummaryView.swift
@@ -11,9 +11,8 @@ import SnapKit
 class SummaryView: UIView {
     
     private lazy var summaryStack: UIStackView = {
-        let view = UIStackView(arrangedSubviews: [title, summary])
+        let view = UIStackView(arrangedSubviews: [title, summary, expand])
         view.axis = .vertical
-        view.alignment = .leading
         view.spacing = 8
         return view
     }()
@@ -23,6 +22,7 @@ class SummaryView: UIView {
         label.text = "Summary"
         label.font = .systemFont(ofSize: 18, weight: .bold)
         label.textColor = .black
+        label.textAlignment = .left
         return label
     }()
     
@@ -31,9 +31,29 @@ class SummaryView: UIView {
         label.font = .systemFont(ofSize: 14)
         label.textColor = .darkGray
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
+        label.lineBreakMode = .byTruncatingTail
+        label.textAlignment = .left
         return label
     }()
+    
+    private let expand: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("더 보기", for: .normal)
+        button.setTitleColor(.systemBlue, for: .normal)
+        button.contentHorizontalAlignment = .right
+        return button
+    }()
+    
+    /// 더 보기 , 접기
+    private var isExpanded: Bool = false
+    
+    private func saveState() {
+        UserDefaults.standard.set(isExpanded, forKey: currentBookTitle)
+    }
+    
+    private var currentBookTitle: String = ""
+
+    
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -50,9 +70,34 @@ class SummaryView: UIView {
             $0.edges.equalToSuperview()
         }
         
+        expand.addTarget(self, action: #selector(toggleText), for: .touchUpInside) // 버튼을 터치했다가 손을 뗐을 때
+        
     }
     
     func configure(book: Book) {
+        currentBookTitle = book.title
         summary.text = book.summary
+
+        let isLongText = book.summary.count > 450
+        expand.isHidden = !isLongText
+
+        isExpanded = UserDefaults.standard.bool(forKey: currentBookTitle)
+        updateSummaryDisplay()
+        
+        expand.isHidden = !isLongText
     }
+
+    
+    // 더보기/접기 기능
+    @objc private func toggleText() {
+        isExpanded.toggle()
+        saveState()
+        updateSummaryDisplay()
+    }
+
+    private func updateSummaryDisplay() {
+        summary.numberOfLines = isExpanded ? 0 : 7
+        expand.setTitle(isExpanded ? "접기" : "더 보기", for: .normal)
+    }
+
 }

--- a/HarryPotterSeriesApp/Home/BookDetails/Header/Info/View/BookInfoView.swift
+++ b/HarryPotterSeriesApp/Home/BookDetails/Header/Info/View/BookInfoView.swift
@@ -22,7 +22,6 @@ class BookInfoView: UIView {
     private lazy var authorStack: UIStackView = {
         let view = UIStackView(arrangedSubviews: [authorTitleLabel, authorLabel])
         view.axis = .horizontal
-        view.alignment = .leading
         view.spacing = 5
         return view
     }()
@@ -30,7 +29,6 @@ class BookInfoView: UIView {
     private lazy var releasedStack: UIStackView = {
         let view = UIStackView(arrangedSubviews: [releasedTitleLabel, releasedLabel])
         view.axis = .horizontal
-        view.alignment = .leading
         view.spacing = 5
         return view
     }()
@@ -38,7 +36,6 @@ class BookInfoView: UIView {
     private lazy var pagesStack: UIStackView = {
         let view = UIStackView(arrangedSubviews: [pagesTitleLabel, pagesLabel])
         view.axis = .horizontal
-        view.alignment = .leading
         view.spacing = 5
         return view
     }()
@@ -46,7 +43,7 @@ class BookInfoView: UIView {
     // MARK: - UI 요소
     private let titleLabel: UILabel = {
         var label = UILabel()
-        label.textAlignment = .center
+        label.textAlignment = .left
         label.font = .systemFont(ofSize: 20, weight: .bold)
         label.textColor = .black
         label.numberOfLines = 2
@@ -58,7 +55,7 @@ class BookInfoView: UIView {
     private let authorTitleLabel: UILabel = {
         var label = UILabel()
         label.text = "Author"
-        label.textAlignment = .center
+        label.textAlignment = .left
         label.font = .systemFont(ofSize: 16, weight: .bold)
         label.textColor = .black
         return label
@@ -66,7 +63,7 @@ class BookInfoView: UIView {
     
     private let authorLabel: UILabel = {
         var label = UILabel()
-        label.textAlignment = .center
+        label.textAlignment = .left
         label.font = .systemFont(ofSize: 18)
         label.textColor = .darkGray
         return label
@@ -75,7 +72,7 @@ class BookInfoView: UIView {
     private let releasedTitleLabel: UILabel = {
         var label = UILabel()
         label.text = "Released"
-        label.textAlignment = .center
+        label.textAlignment = .left
         label.font = .systemFont(ofSize: 16, weight: .bold)
         label.textColor = .black
         
@@ -84,7 +81,7 @@ class BookInfoView: UIView {
     
     private let releasedLabel: UILabel = {
         var label = UILabel()
-        label.textAlignment = .center
+        label.textAlignment = .left
         label.font = .systemFont(ofSize: 14)
         label.textColor = .gray
         
@@ -94,7 +91,7 @@ class BookInfoView: UIView {
     private let pagesTitleLabel: UILabel = {
         var label = UILabel()
         label.text = "Pages"
-        label.textAlignment = .center
+        label.textAlignment = .left
         label.font = .systemFont(ofSize: 14, weight: .bold)
         label.textColor = .black
         
@@ -103,7 +100,7 @@ class BookInfoView: UIView {
     
     private let pagesLabel: UILabel = {
         var label = UILabel()
-        label.textAlignment = .center
+        label.textAlignment = .left
         label.font = .systemFont(ofSize: 14)
         label.textColor = .gray
         


### PR DESCRIPTION
https://github.com/user-attachments/assets/800ccd10-a936-4216-98fd-c1615960c48d

🧑🏻‍💻 Summary 접기/더보기 기능을 구현해보세요.

- 글자수가 450자 이상인 경우 `…` 말줄임표 표시 및 `더보기` 버튼 표시
    - 참고로, 2권(시리즈 두번째)의 요약 내용은 글자수가 450자 미만이므로 더보기 버튼이 표시되지 않아야 합니다.
- `더보기` 버튼을 누르면 요약 텍스트 전체가 표시되고 `더보기` 버튼은 `접기` 버튼으로 변경
- 더보기/접기 상태를 저장해 앱을 종료했다가 다시 실행했을 때에도 마지막 상태를 기억하여 표시
    - `더보기` 버튼을 눌러 Summary를 펼친 상태로 앱을 종료했다면, 앱을 다시 실행했을 때 펼쳐진 상태로 표시되어 있습니다.
    반대로 `접기`버튼을 눌러 접은 상태로 종료했다면 앱 종료 후 다시 실행했을 때 접은 상태로 표시되어 있습니다.
